### PR TITLE
Collapse years of newsletters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,48 +27,73 @@ A collection of resources related to [Gio](https://gioui.org/).
 [17](https://www.youtube.com/watch?v=1g5bKeTouX4)
 
 # Gio News
-* [February 2023](https://gioui.org/news/2023-02)
-* [January 2023](https://gioui.org/news/2023-01)
-* [December 2022](https://gioui.org/news/2022-12)
-* [November 2022](https://gioui.org/news/2022-11)
-* [October 2022](https://gioui.org/news/2022-10)
-* [September 2022](https://gioui.org/news/2022-09)
-* [August 2022](https://gioui.org/news/2022-08)
-* [July 2022](https://gioui.org/news/2022-07)
-* [June 2022](https://gioui.org/news/2022-06)
-* [May 2022](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FSPjM%3DKcEa2AmR6qkQP-YMVsR-huerDkwwT0ZXoJ7gshQ%40mail.gmail.com%3E)
-* [April 2022](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQo1q%2BcBd3Y6H_e%3DRvodcHnNW8Je6FHz4vqsQ7Nu1Oghg%40mail.gmail.com%3E)
-* [March 2022](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FSwzPb5BvoLK4sUgRFvUMcBk1_h3RqbmHVWceCRFLYs9Q%40mail.gmail.com%3E)
-* [February 2022](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQPxxZOFFT-66s8eT5KM5%2BBAX4Wf-QwsK4h79X%2BAwBFCA%40mail.gmail.com%3E)
-* [January + 0.5*February 2022](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FSWbqzHkWpzsOBLD9J3GmDgD5S6wO6ZqVoRKLq41GkObQ%40mail.gmail.com%3E)
-* [December 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FR0ELue8DRipJS_Cq_QcBkS4r%2Bm0ZVqfuRQxEKpetPssg%40mail.gmail.com%3E)
-* [November 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTTjYQew%2BHXzOF-OoABrS47MK8Sf_qDFedubwjEbibbig%40mail.gmail.com%3E)
-* [October 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FRcn-3TJ3N0JTSBfv1F61WJSSmjbmN5mwvRX98ChghVqA%40mail.gmail.com%3E)
-* [September 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQOmXb8i%3DvAZA3emTw%2BDUn5YJO4WUQQeVFzVY-zfGcgXg%40mail.gmail.com%3E)
-* ["August" 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQHP6EkPF-6Csorv6ZQHc_TbeVr7BtbzLXK%3DjpY3_OHqg%40mail.gmail.com%3E)
-* [July 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQF-z258qsHJko1WLhtK3P1Vp_5uAjHibfyMY60ULW1vw%40mail.gmail.com%3E)
-* [June 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FRPnW9X6vTQLbadsdKOCwb1HM5yd3M8%2BLcAs7wubAET0A%40mail.gmail.com%3E)
-* [May 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTyqMKofES7L3kC-OjhkqkgVtbHsN4TMb6fws%3DOUKACAA%40mail.gmail.com%3E)
-* [0.7*April 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTTjuwpgvDtH8OxJ4bRP3x8-M9pLcA73_skWeJK4GTqog%40mail.gmail.com%3E)
-* [(March + 0.3*April) 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQcXKpmbvOodi5VE6MnwDRHdGs0KpDmjLjFgwetY7KeUw%40mail.gmail.com%3E)
-* [February 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTw42ZiMtrb-CeEyKcK%3DfqRFPu4ABydsQ93_Bi%2BXU%3DJqA%40mail.gmail.com%3E)
-* [January 2021](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTeOFa%3D%3D9CuuRFBpHLVS8VDUJeggvsq3EpXHvmgq1zc3Q%40mail.gmail.com%3E)
-* [December 2020](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FT9ckTfnMF4hjKim7o_q2u8-f_ZatmKyWO7%2BBUgpaTf4A%40mail.gmail.com%3E)
-* [November 2020](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQKcL_-6AEK%3DQ7c-z_X29Tm_d4QpYWjdr2_P2P1HA2wFQ%40mail.gmail.com%3E)
-* [October 2020](https://lists.sr.ht/~eliasnaur/gio/%3CC6BDPG4TNM10.2GO1LJH3EF83E%40vendetta%3E)
-* [August 2020](https://lists.sr.ht/~eliasnaur/gio/%3CC4N9ZSRB761J.EGVHQQ5EHCJM%40themachine%3E)
-* [July 2020](https://lists.sr.ht/~eliasnaur/gio/%3CC3WYH51C7KE8.ZWWSUFA02DZY%40themachine%3E)
-* [June 2020](https://lists.sr.ht/~eliasnaur/gio/%3CC391UI3QW1VH.3IPCN4GELYV54%40themachine%3E)
-* [May 2020](https://lists.sr.ht/~eliasnaur/gio/%3CC2HUGIUUAE0K.7BXV54XYE05I%40themachine%3E)
-* [April 2020](https://lists.sr.ht/~eliasnaur/gio/%3CC1SDKC261IN4.3TN8HT3WHK1OK%40testmac%3E)
-* [March 2020](https://lists.sr.ht/~eliasnaur/gio/%3CC11X6PPMHM9C.1YULATSWV7AL0%40testmac%3E)
-* [February 2020](https://lists.sr.ht/~eliasnaur/gio/%3CC0CEVJ4DUL7J.3O0FATZ46ILQ6%40toolbox%3E)
-* [January 2020](https://lists.sr.ht/~eliasnaur/gio/%3CBZMX52GW66KW.PH0XPNFWMU3I%40testmac%3E)
-* [December 2019](https://lists.sr.ht/~eliasnaur/gio/%3CBYWLTWTU8MFC.1OHQHYPX3TM5A%40testmac%3E)
-* [November 2019](https://lists.sr.ht/~eliasnaur/gio/%3CBY8SBB0RKDHU.1X0F4L2DGUBMB%40toolbox%3E)
-* [October 2019](https://lists.sr.ht/~eliasnaur/gio/%3CBXFS2E6WPR6G.2F1JS1VYEW3P9%40testmac%3E)
-* [September 2019](https://lists.sr.ht/~eliasnaur/gio/%3CBWQBMYQFDKDP.2B69M881AOXFX%40toolbox%3E)
-* [August 2019](https://lists.sr.ht/~eliasnaur/gio/%3CCAMAFT9VHD_8N92k1bKvR4ambpcnZD8WAqryKmtHR7kUNYgJoMw%40mail.gmail.com%3E)
+
+<details open>
+<summary>2023</summary>
+
+* [February](https://gioui.org/news/2023-02)
+* [January](https://gioui.org/news/2023-01)
+</details>
+
+<details>
+<summary>2022</summary>
+
+* [December](https://gioui.org/news/2022-12)
+* [November](https://gioui.org/news/2022-11)
+* [October](https://gioui.org/news/2022-10)
+* [September](https://gioui.org/news/2022-09)
+* [August](https://gioui.org/news/2022-08)
+* [July](https://gioui.org/news/2022-07)
+* [June](https://gioui.org/news/2022-06)
+* [May](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FSPjM%3DKcEa2AmR6qkQP-YMVsR-huerDkwwT0ZXoJ7gshQ%40mail.gmail.com%3E)
+* [April](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQo1q%2BcBd3Y6H_e%3DRvodcHnNW8Je6FHz4vqsQ7Nu1Oghg%40mail.gmail.com%3E)
+* [March](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FSwzPb5BvoLK4sUgRFvUMcBk1_h3RqbmHVWceCRFLYs9Q%40mail.gmail.com%3E)
+* [February](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQPxxZOFFT-66s8eT5KM5%2BBAX4Wf-QwsK4h79X%2BAwBFCA%40mail.gmail.com%3E)
+* [January + 0.5*February](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FSWbqzHkWpzsOBLD9J3GmDgD5S6wO6ZqVoRKLq41GkObQ%40mail.gmail.com%3E)
+</details>
+
+<details>
+<summary>2021</summary>
+
+* [December](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FR0ELue8DRipJS_Cq_QcBkS4r%2Bm0ZVqfuRQxEKpetPssg%40mail.gmail.com%3E)
+* [November](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTTjYQew%2BHXzOF-OoABrS47MK8Sf_qDFedubwjEbibbig%40mail.gmail.com%3E)
+* [October](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FRcn-3TJ3N0JTSBfv1F61WJSSmjbmN5mwvRX98ChghVqA%40mail.gmail.com%3E)
+* [September](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQOmXb8i%3DvAZA3emTw%2BDUn5YJO4WUQQeVFzVY-zfGcgXg%40mail.gmail.com%3E)
+* [August](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQHP6EkPF-6Csorv6ZQHc_TbeVr7BtbzLXK%3DjpY3_OHqg%40mail.gmail.com%3E)
+* [July](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQF-z258qsHJko1WLhtK3P1Vp_5uAjHibfyMY60ULW1vw%40mail.gmail.com%3E)
+* [June](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FRPnW9X6vTQLbadsdKOCwb1HM5yd3M8%2BLcAs7wubAET0A%40mail.gmail.com%3E)
+* [May](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTyqMKofES7L3kC-OjhkqkgVtbHsN4TMb6fws%3DOUKACAA%40mail.gmail.com%3E)
+* [0.7*April](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTTjuwpgvDtH8OxJ4bRP3x8-M9pLcA73_skWeJK4GTqog%40mail.gmail.com%3E)
+* [(March + 0.3*April)](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQcXKpmbvOodi5VE6MnwDRHdGs0KpDmjLjFgwetY7KeUw%40mail.gmail.com%3E)
+* [February](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTw42ZiMtrb-CeEyKcK%3DfqRFPu4ABydsQ93_Bi%2BXU%3DJqA%40mail.gmail.com%3E)
+* [January](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FTeOFa%3D%3D9CuuRFBpHLVS8VDUJeggvsq3EpXHvmgq1zc3Q%40mail.gmail.com%3E)
+</details>
+
+<details>
+<summary>2020</summary>
+
+* [December](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FT9ckTfnMF4hjKim7o_q2u8-f_ZatmKyWO7%2BBUgpaTf4A%40mail.gmail.com%3E)
+* [November](https://lists.sr.ht/~eliasnaur/gio/%3CCAFcc3FQKcL_-6AEK%3DQ7c-z_X29Tm_d4QpYWjdr2_P2P1HA2wFQ%40mail.gmail.com%3E)
+* [October](https://lists.sr.ht/~eliasnaur/gio/%3CC6BDPG4TNM10.2GO1LJH3EF83E%40vendetta%3E)
+* [August](https://lists.sr.ht/~eliasnaur/gio/%3CC4N9ZSRB761J.EGVHQQ5EHCJM%40themachine%3E)
+* [July](https://lists.sr.ht/~eliasnaur/gio/%3CC3WYH51C7KE8.ZWWSUFA02DZY%40themachine%3E)
+* [June](https://lists.sr.ht/~eliasnaur/gio/%3CC391UI3QW1VH.3IPCN4GELYV54%40themachine%3E)
+* [May](https://lists.sr.ht/~eliasnaur/gio/%3CC2HUGIUUAE0K.7BXV54XYE05I%40themachine%3E)
+* [April](https://lists.sr.ht/~eliasnaur/gio/%3CC1SDKC261IN4.3TN8HT3WHK1OK%40testmac%3E)
+* [March](https://lists.sr.ht/~eliasnaur/gio/%3CC11X6PPMHM9C.1YULATSWV7AL0%40testmac%3E)
+* [February](https://lists.sr.ht/~eliasnaur/gio/%3CC0CEVJ4DUL7J.3O0FATZ46ILQ6%40toolbox%3E)
+* [January](https://lists.sr.ht/~eliasnaur/gio/%3CBZMX52GW66KW.PH0XPNFWMU3I%40testmac%3E)
+</details>
+
+<details>
+<summary>2019</summary>
+
+* [December](https://lists.sr.ht/~eliasnaur/gio/%3CBYWLTWTU8MFC.1OHQHYPX3TM5A%40testmac%3E)
+* [November](https://lists.sr.ht/~eliasnaur/gio/%3CBY8SBB0RKDHU.1X0F4L2DGUBMB%40toolbox%3E)
+* [October](https://lists.sr.ht/~eliasnaur/gio/%3CBXFS2E6WPR6G.2F1JS1VYEW3P9%40testmac%3E)
+* [September](https://lists.sr.ht/~eliasnaur/gio/%3CBWQBMYQFDKDP.2B69M881AOXFX%40toolbox%3E)
+* [August](https://lists.sr.ht/~eliasnaur/gio/%3CCAMAFT9VHD_8N92k1bKvR4ambpcnZD8WAqryKmtHR7kUNYgJoMw%40mail.gmail.com%3E)
+</details>
 
 ## Develop with Gio
 * [Getting Started](https://gioui.org/#getting-started)


### PR DESCRIPTION
This PR puts the newsletters behind `<details>` elements by year, but the only the current year is expanded by default.